### PR TITLE
fix(cae): add v. abbreviation expansion to caeab_input

### DIFF
--- a/v02/distinctfiles/cae/pywork/caeab/caeab_input.txt
+++ b/v02/distinctfiles/cae/pywork/caeab/caeab_input.txt
@@ -91,6 +91,7 @@ t.	<id>t.</id> <disp>time</disp>
 superl.	<id>superl.</id> <disp>superlative</disp>
 s.v.	<id>s.v.</id> <disp>sub voce</disp>
 trans.	<id>trans.</id> <disp>transitive</disp>
+v.	<id>v.</id> <disp>vide, see</disp>
 vocat.	<id>vocat.</id> <disp>vocative</disp>
 voc.	<id>voc.</id> <disp>vocative</disp>
 w.	<id>w.</id> <disp>with</disp>


### PR DESCRIPTION
Adds the missing v. entry (vide, see) to caeab_input.txt. The ab tag appears 425 times in cae.txt but had no expansion, causing blank tooltips. Fixes sanskrit-lexicon/COLOGNE#331