### PR TITLE
Add canonical digentry.py to makotemplates (headless family regains a head)

### DIFF
--- a/v02/makotemplates/pywork/digentry.py
+++ b/v02/makotemplates/pywork/digentry.py
@@ -1,0 +1,103 @@
+#-*- coding:utf-8 -*-
+"""digentry.py
+  Module to read a digitization 
+  and generate a list of Entry objects
+  Adapted for temp_pwkvn_22.txt
+"""
+from __future__ import print_function
+import sys,re,codecs
+
+class Entry(object):
+ Ldict = {}
+ def __init__(self,lines,linenum1,linenum2):
+  # linenum1,2 are int
+  self.metaline = lines[0]
+  self.lend = lines[-1]  # the <LEND> line
+  self.datalines = lines[1:-1]  # the non-meta lines
+  # parse the meta line into a dictionary
+  self.metad = parseheadline(self.metaline)
+  self.linenum1 = linenum1
+  self.linenum2 = linenum2
+  L = self.metad['L']
+  if L in self.Ldict:
+   print("Entry init error: duplicate L",L,linenum1)
+   exit(1)
+  self.Ldict[L] = self
+  self.lsarr = []
+  
+def init(filein):
+ # slurp lines
+ with codecs.open(filein,encoding='utf-8',mode='r') as f:
+  lines = [line.rstrip('\r\n') for line in f]
+ recs=[]  # list of Entry objects
+ inentry = False  
+ idx1 = None
+ idx2 = None
+ for idx,line in enumerate(lines):
+  if inentry:
+   if line.startswith('<LEND>'):
+    idx2 = idx
+    entrylines = lines[idx1:idx2+1]
+    linenum1 = idx1 + 1
+    linenum2 = idx2 + 1
+    entry = Entry(entrylines,linenum1,linenum2)
+    recs.append(entry)
+    # prepare for next entry
+    idx1 = None
+    idx2 = None
+    inentry = False
+   elif line.startswith('<L>'):  # error
+    print('init_entries Error 1. Not expecting <L>')
+    print("line # ",idx+1)
+    print(line.encode('utf-8'))
+    exit(1)
+   else: 
+    # keep looking for <LEND>
+    continue
+  else:
+   # inentry = False. Looking for '<L>'
+   if line.startswith('<L>'):
+    idx1 = idx
+    inentry = True
+   elif line.startswith('<LEND>'): # error
+    print('init_entries Error 2. Not expecting <LEND>')
+    print("line # ",idx+1)
+    print(line.encode('utf-8'))
+    exit(1)
+   else: 
+    # keep looking for <L>
+    continue
+ # when all lines are read, we should have inentry = False
+ if inentry:
+  print('digentry.init Error 3. for file',filein)
+  print('Last entry not closed. Open entry starts at line',idx1+1)
+  exit(1)
+
+ print(len(lines),"lines read from",filein)
+ print(len(recs),"entries found")
+ return recs
+
+def parseheadline(headline):
+ """
+  function to parse a 'metaline' and return a dictionary.
+  Example:
+  headline = <L>16850<pc>292-3<k1>visarga<k2>visarga<h>1<e>
+  returns dictionary
+  {'L': '16850', 
+   'pc': '292-3',
+   'k1': 'visarga', 
+   'k2': 'visarga', 
+   'h': '1', 
+   'e': ''}
+ """
+ headline = headline.strip()
+ splits = re.split('[<]([^>]*)[>]([^<]*)',headline)
+ result = {}
+ for i in range(len(splits)):
+  if i % 3 == 1:
+   result[splits[i]] = splits[i+1]
+ return result
+
+if __name__=="__main__":
+ filein = sys.argv[1] #  xxx.txt (path to digitization of xxx)
+ entries = init(filein)


### PR DESCRIPTION
## What

Adds a single file — `v02/makotemplates/pywork/digentry.py` — restoring the missing canonical source for the `digentry.py` build-pipeline family.

## Why

A cross-org code-duplication census ([csl-observatory H688, PR #85](https://github.com/sanskrit-lexicon/csl-observatory/pull/85)) found `digentry.py` **headless**: 193 leaf copies across 15 repos, of which **183 are byte-identical** (one dominant template cohort), but **zero copy under csl-pywork**. [SHARED_CODE.md §3](https://github.com/gasyoun/github-spine/blob/main/SHARED_CODE.md) names csl-pywork `makotemplates` as this family's origin, yet no master existed to regenerate from — so the standing rule "fix the template, then regenerate" had no template to fix.

This restores the modal deployed version verbatim (its LF-normalized form, matching the sibling template files' line-ending convention here), placed alongside the other correction-pipeline templates (`make_xml.py`, `parseheadline.py`, `updateByLine.py`).

## Safety

- **No behavioural change** to any generated dictionary: the added file is byte-identical to the 183-copy deployed cohort (modulo the repo's own LF line-ending convention).
- Content-only addition; nothing else in the repo is touched.

_The reconcile for the other four census-flagged families (`transcoder.py`, `updateByLine.py`, `parseheadline.py`, php endpoints) needed **no csl-pywork change** — in each the csl-pywork template already **leads** the deployed cohort (newer/cleaner code), so the census's "template lags deployment" flag was inverted for them. Full per-family verdict table: [csl-observatory reports/template_deployment_reconcile_H787.md](https://github.com/sanskrit-lexicon/csl-observatory/blob/h787-template-reconcile/reports/template_deployment_reconcile_H787.md)._

Opus 4.8 (`claude-opus-4-8`), H787.