### PR TITLE
docs(H1783): residual salvage — .gitattributes fix, CITATION.cff v0.2.1 sync

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,8 @@ type: software
 title: csl-pywork
 message: If you use this software, please cite it.
 license: GPL-3.0
+version: 0.2.1
+date-released: '2026-07-29'
 repository-code: https://github.com/sanskrit-lexicon/csl-pywork
 keywords:
   - sanskrit

--- a/docs/GENERATION_MANUAL.md
+++ b/docs/GENERATION_MANUAL.md
@@ -127,10 +127,12 @@ Windows notes that bite in practice:
   (`python3` → `python`) before running anything.
 - Run the `.sh` scripts under **Git Bash** (or WSL/apache-less bash), never
   PowerShell/cmd.
-- Line endings: the repo has no `.gitattributes` yet
-  ([issue #52](https://github.com/sanskrit-lexicon/csl-pywork/issues/52)) —
-  keep generated and change files **LF**, and never introduce a UTF-8 BOM
-  (see §7 traps).
+- Line endings: the repo's
+  [`.gitattributes`](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/.gitattributes)
+  normalises `.sh`/`.py`/`.txt`/`.tsv`/`.yml` to **LF**
+  ([issue #52](https://github.com/sanskrit-lexicon/csl-pywork/issues/52) tracks
+  the remaining scope) — keep generated and change files LF, and never
+  introduce a UTF-8 BOM (see §7 traps).
 
 ---
 
@@ -512,7 +514,7 @@ is likewise an older broad-regeneration script kept for reference.
   (parse the `<L>`-line metadata) are the two most commonly vendored helpers
   after `updateByLine.py`.
 - **Known open debt:** [issue #52](https://github.com/sanskrit-lexicon/csl-pywork/issues/52)
-  (no `.gitattributes`), [issue #53](https://github.com/sanskrit-lexicon/csl-pywork/issues/53)
+  (`.gitattributes` scope — the file itself exists, §3), [issue #53](https://github.com/sanskrit-lexicon/csl-pywork/issues/53)
   (modernise `redo_xampp_selective.sh`), [issue #63](https://github.com/sanskrit-lexicon/csl-pywork/issues/63)
   (master/main branch confusion — the default branch is `main`).
 - **Improvement backlog for this manual:** see

--- a/docs/GENERATION_MANUAL.meta.md
+++ b/docs/GENERATION_MANUAL.meta.md
@@ -76,5 +76,6 @@ workflow's regeneration step.
 |---|---|---|
 | 28-07-2026 | Initial authoring (H1783) | Fable 5 (`claude-fable-5`) |
 | 29-07-2026 | Dual-run adjudication graft from PR #71's parallel pass | Fable 5 (`claude-fable-5`) |
+| 29-07-2026 | Residual salvage from the PR #71 session: fixed the §3 claim that no `.gitattributes` exists (it does, on `main`), reworded the §13 known-debt row accordingly, synced `CITATION.cff` `version`/`date-released` to the v0.2.1 release | Fable 5 (`claude-fable-5`) |
 
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
**Residual salvage after the dual run.** H1783 was executed by two concurrent Fable 5 (`claude-fable-5`) sessions; [PR #70](https://github.com/sanskrit-lexicon/csl-pywork/pull/70) merged first and stays canonical, and [PR #73](https://github.com/sanskrit-lexicon/csl-pywork/pull/73) already grafted most of the second pass''s deltas ([PR #71](https://github.com/sanskrit-lexicon/csl-pywork/pull/71), closed). This PR carries only the three deltas that graft missed:

- **Factual fix:** §3 (and the §13 known-debt row) claimed the repo has no `.gitattributes` — [it exists on `main`](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/.gitattributes) (`* text=auto` + LF for `.sh/.py/.txt/.tsv/.yml`). [Issue #52](https://github.com/sanskrit-lexicon/csl-pywork/issues/52) stays referenced for remaining scope.
- **Release hygiene:** `CITATION.cff` gets `version: 0.2.1` + `date-released` — the sync owed at the v0.2.1 cut.
- Metadoc revision-history row documenting this residual pass.

No changelog entry: typo-class docs fix + citation plumbing for the already-cut release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)