### PR TITLE
ai-wip: journal H1783 completion in .ai_state.md

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -1,6 +1,6 @@
 # Project Objective: Maintain the Cologne build system (generate_dict.sh, XML validation, display generation) shared by all CDSL dictionary repos
 
-_Created: 03-07-2026 · Last updated: 03-07-2026_
+_Created: 03-07-2026 · Last updated: 29-07-2026_
 
 ## ➡️ Next Steps (Queue)
 
@@ -16,6 +16,7 @@ _Created: 03-07-2026 · Last updated: 03-07-2026_
 
 ## ✅ Completed (Recent only)
 
+- 2026-07-28/29 (Fable 5, `claude-fable-5`, two concurrent sessions — dual run adjudicated): **H1783 operator manual.** [docs/GENERATION_MANUAL.md](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/docs/GENERATION_MANUAL.md) + [meta](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/docs/GENERATION_MANUAL.meta.md) + README link (PRs #70/#72/#73/#75; PR #71 closed as the adjudicated parallel pass; releases v0.2.0/v0.2.1; CITATION.cff synced). Backlog for the manual lives in its metadoc.
 - 2026-07-03 (Sonnet 5, `claude-sonnet-5`): **CI + dependency hygiene.**
   - **D3 CI fix** — `.github/workflows/xml-parse.yml` committed-XML job was failing on a Mako template (`v02/makotemplates/pywork/redo_xml_20210415.xml`) and a multi-root tab-map fragment (`v02/distinctfiles/mw/pywork/westmwtab/mwdp.xml`) — both false positives, the real `make_xml`-build job was passing throughout. Fixed to skip `makotemplates/` and wrap fragment content so well-formedness is still checked without requiring a single root. Verified green: run `b11af2d`.
   - **CodeQL v4 fix** — `.github/workflows/codeql.yml` rewritten to analyze `python` (this repo's actual primary language) instead of the invalid `php`, on `codeql-action@v4` + `checkout@v5`. Verified green (see Dev Notes above for root cause). Commit `cd0db88`.


### PR DESCRIPTION
Session-state protocol follow-through: neither H1783 session journaled the completed work in `.ai_state.md`. One Completed entry + date bump, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)