### PR TITLE
docs(claude): H3045 14d freshness — bump header, name xmlchk_xampp.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-_Created: 06-05-2026 · Last updated: 16-08-2026_
+_Created: 06-05-2026 · Last updated: 20-08-2026_
 
 **csl-pywork** is the Cologne **generator**. It turns
 [csl-orig](https://github.com/sanskrit-lexicon/csl-orig) digitised text into
@@ -29,7 +29,9 @@ sh generate_dict.sh mw ../../MWScan/2020
 `generate_dict.sh <dict> <outdir>` copies orig → renders Mako templates →
 runs [`make_xml.py`](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/v02/makotemplates/pywork/make_xml.py)
 → builds SQLite / downloads / web support. Batch: `redo_xampp_all.sh` (local)
-or `redo_cologne_all.sh` (server).
+or `redo_cologne_all.sh` (server). After a generate, DTD-validate with
+[`xmlchk_xampp.sh`](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/v02/xmlchk_xampp.sh)
+`<dict>` (XAMPP layout).
 
 **Windows / no XAMPP:**
 


### PR DESCRIPTION
H3045 (Grok 4.6) — Refresh stale CLAUDE.md (SLA 14d, H2816).

Spot-check on origin/main (post-H2821 PR https://github.com/sanskrit-lexicon/csl-pywork/pull/82):
- [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md) still live and still the correction sequence.
- [v02/readme.md](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/v02/readme.md) still matches generate_dict.sh / sibling layout.
- Content of the generator runbook was accurate; no taxonomy-stub leftover on origin.

This pass:
- Bumps _Created: 06-05-2026 · Last updated: 20-08-2026_ (git first-commit date; edited today).
- Names [02/xmlchk_xampp.sh](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/v02/xmlchk_xampp.sh) as the post-generate DTD check the correction workflow already cites.

CLAUDE.md-only. No csl-orig source write.

Executor: Grok 4.6 (grok-4.6).